### PR TITLE
Changed dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9, <3.11"
-llvmlite = "^0.40"
+llvmlite = "^0.41"
 anndata = ">=0.9.0, <0.10.0"
 scipy = "*"
 scvi-tools = ">=0.20.3,<1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.9, <3.11"
 llvmlite = "^0.40"
+anndata = ">=0.9.0, <0.10.0"
 scipy = "*"
 scvi-tools = ">=0.20.3,<1.0.0"
 importlib-metadata = "*"


### PR DESCRIPTION
`anndata` 0.10.0 updated changed a class name from `SparseDataset` to `BaseCompressedSparseDataset` and `scvi-tools` has not updated to be compatible yet.
Changing `anndata` to 0.9.2