### PR TITLE
fix jax deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ adjustText = "*"
 numpy = '>=1.22.4,<1.24'
 seaborn = "*"
 gdown = "*"
-jax = "^0.4.16"
+jax = ">=0.4.16, <0.4.24"
+jaxlib = ">=0.4.16, <0.4.24"
 torchaudio = ">2.0.0,<=2.0.1"
 
 # Optional dependencies


### PR DESCRIPTION
# Issue

 Encountered by @erialc-cal

Importing cpa fails after following the installation tutorial due to the call to jax.random.KeyArray in ... which was already depracated in 0.4.16 and recently (Feb. 6th) removed in 0.4.24, see [here](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-24-feb-6-2024) for more details.

`>>> import cpa`
`[rank: 0] Global seed set to 0`
`...[trace]...`
`AttributeError: module 'jax.random' has no attribute 'KeyArray'`


# How to  Reproduce

1. `conda create -n cpa python=3.9`
2. `conda activate cpa`
3. `pip install git+https://github.com/theislab/cpa`
4. `python`
5. `>>> import cpa`


# Fix/Changes

Added jax version upper bound in pyproject.toml, also added same for jaxlib to avoid consistency errors for jax.
